### PR TITLE
fix: invalid `pagesconfig.json` in the getting started page

### DIFF
--- a/docs-source/getting-started/quick-start.md
+++ b/docs-source/getting-started/quick-start.md
@@ -56,7 +56,7 @@ To configure the plugin, create a `pagesconfig.json` file in the same directory 
 				}
 			]
 		}
-	]
+	],
 	"theme": "pages-plugin"
 }
 ```


### PR DESCRIPTION
There is a missing comma in the sample `pagesconfig.json`.