### PR TITLE
chore(license): update license field in package.json to reflect LICENSE file

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "plugin"
   ],
   "author": "Mike Patterson",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/mipatterson/typedoc-plugin-pages/issues"
   },


### PR DESCRIPTION
The field read `MIT` while the file indicated `Apache-2.0`. Used the LICENSE file as the source of truth.